### PR TITLE
[hotfix] fix sending mail to already end meeting

### DIFF
--- a/utils/sendMail.js
+++ b/utils/sendMail.js
@@ -18,9 +18,11 @@ async function sendMail(
   let mailOptions;
 
   if (type === "reservation") {
-    const { _id, reservation, title } = await Meeting.findById(
+    const { _id, reservation, title, isEnd } = await Meeting.findById(
       meetingId
     ).lean();
+
+    if (isEnd) return;
 
     mailOptions = {
       from: process.env.GMAIL_ID,


### PR DESCRIPTION
## 칸반 카드번호
none
## 칸반 카드 링크
none
## 구현내용
- 이미 종료된 미팅에 이메일을 보내지 않도록 로직을 수정했습니다. 